### PR TITLE
enable direction switch

### DIFF
--- a/presentation.py
+++ b/presentation.py
@@ -1,5 +1,6 @@
 import yaml
 import sys
+from enum import Enum, auto
 from pptx import Presentation
 from pptx.util import Inches, Pt
 from pptx.enum.text import PP_ALIGN
@@ -10,6 +11,10 @@ SLIDE_HEIGHT = Inches(7.5)
 TOP_MARGIN = Inches(0.3)
 SIDE_MARGIN = Inches(0.6)
 TITLE_HEIGHT = Inches(1.5)
+
+class Direction(Enum):
+    HORIZONTAL = auto()
+    VERTICAL = auto()
 
 def add_center_title(slide, title):
     height = TITLE_HEIGHT
@@ -25,12 +30,16 @@ def add_center_title(slide, title):
     p.alignment = PP_ALIGN.CENTER
     p.text = title
 
-def add_top_title(slide, title):
+def add_title(slide, title, direction = Direction.VERTICAL):
     left = SIDE_MARGIN
     height = TITLE_HEIGHT
-    width = SLIDE_WIDTH - 2 * left
-    font_size = Pt(40)
     top = TOP_MARGIN
+    font_size = Pt(40)
+    if direction == Direction.VERTICAL:
+        width = SLIDE_WIDTH - 2 * left
+    else:
+        width = SLIDE_WIDTH / 2 - left - SIDE_MARGIN
+
     tx_box = slide.shapes.add_textbox(left, top, width, height)
     tf = tx_box.text_frame
     tf.clear()
@@ -39,50 +48,34 @@ def add_top_title(slide, title):
     p.alignment = PP_ALIGN.LEFT
     p.text = title
 
-def add_side_title(slide, title):
-    left = SIDE_MARGIN
-    height = TITLE_HEIGHT
-    width = SLIDE_WIDTH / 2 - left - SIDE_MARGIN
-    font_size = Pt(40)
-    top = TOP_MARGIN
-    tx_box = slide.shapes.add_textbox(left, top, width, height)
-    tf = tx_box.text_frame
-    tf.clear()
-    p = tf.add_paragraph()
-    p.font.size = font_size
-    p.alignment = PP_ALIGN.LEFT
-    p.text = title
-
-def add_img(slide, img_file):
+def add_img(slide, img_file, direction = Direction.VERTICAL):
     img = Image.open(img_file)
     w, h = img.size
     ratio = h / w
-    max_width = SLIDE_WIDTH - SIDE_MARGIN * 2
-    max_height = SLIDE_HEIGHT - TITLE_HEIGHT - TOP_MARGIN * 2
-    if max_height / max_width > ratio:
-        width = max_width
-        height = max_width * ratio
-    else:
-        height = max_height
-        width = height / ratio
-    left = (SLIDE_WIDTH - width) / 2
-    top = SLIDE_HEIGHT - height - TOP_MARGIN
-    slide.shapes.add_picture(img_file, left, top, width=width)
 
-def add_side_img(slide, img_file):
-    img = Image.open(img_file)
-    w, h = img.size
-    ratio = h / w
-    max_height = SLIDE_HEIGHT  - TOP_MARGIN * 2
-    max_width = SLIDE_WIDTH / 2 - SIDE_MARGIN
-    if max_height / max_width > ratio:
-        width = max_width
-        height = max_width * ratio
+    if direction == Direction.HORIZONTAL:
+        max_width = SLIDE_WIDTH - SIDE_MARGIN * 2
+        max_height = SLIDE_HEIGHT - TITLE_HEIGHT - TOP_MARGIN * 2
+        if max_height / max_width > ratio:
+            width = max_width
+            height = max_width * ratio
+        else:
+            height = max_height
+            width = height / ratio
+        left = (SLIDE_WIDTH - width) / 2
+        top = SLIDE_HEIGHT - height - TOP_MARGIN
     else:
-        height = max_height
-        width = height / ratio
-    left = SLIDE_WIDTH - SIDE_MARGIN - width
-    top = (SLIDE_HEIGHT - height) / 2
+        max_width = SLIDE_WIDTH / 2 - SIDE_MARGIN
+        max_height = SLIDE_HEIGHT  - TOP_MARGIN * 2
+        if max_height / max_width > ratio:
+            width = max_width
+            height = max_width * ratio
+        else:
+            height = max_height
+            width = height / ratio
+        left = SLIDE_WIDTH - SIDE_MARGIN - width
+        top = (SLIDE_HEIGHT - height) / 2
+
     slide.shapes.add_picture(img_file, left, top, width=width)
 
 def add_text(slide, text):
@@ -99,18 +92,26 @@ def add_text(slide, text):
     p.text = text
 
 def apply_layout(slide, layout):
-    if 'centerTitle' in layout:
-        add_center_title(slide, layout['centerTitle'])
-    if 'topTitle' in layout:
-        add_top_title(slide, layout['topTitle'])
-    if 'sideTitle' in layout:
-        add_side_title(slide, layout['sideTitle'])
-    if 'img' in layout:
-        add_img(slide, layout['img'])
-    if 'sideImg' in layout:
-        add_side_img(slide, layout['sideImg'])
-    if 'text' in layout:
-        add_text(slide, layout['text'])
+    if 'stackDirection' in layout and layout['stackDirection'] == 'horizontal':
+        direction = Direction.HORIZONTAL
+        if 'title' in layout:
+            add_title(slide, layout['title'], direction)
+        if 'centerTitle' in layout:
+            add_center_title(slide, layout['centerTitle'])
+        if 'img' in layout:
+            add_img(slide, layout['img'], direction)
+        if 'text' in layout:
+            add_text(slide, layout['text'])
+    else:
+        direction = Direction.VERTICAL
+        if 'title' in layout:
+            add_title(slide, layout['title'], direction)
+        if 'centerTitle' in layout:
+            add_center_title(slide, layout['centerTitle'])
+        if 'img' in layout:
+            add_img(slide, layout['img'], direction)
+        if 'text' in layout:
+            add_text(slide, layout['text'])
 
 def main(filename, output):
     f = open(filename, 'r')


### PR DESCRIPTION
Thinking of the future growth, I thought it would be better to be able to toggle the direction to stack components!
In future, it's pretty nice if it could be coded like this.
```yaml
slides:
  - centerTitle: "Swallows"

  - stackDirection: "vertical"
    title: "This would be vertical"
    img: "image.png"
    img: "another-image.png" # these two images stack vertically.

  - stackDirection: "horizontal"
    title: "This would be horizontal"
    subtitle: "horizontal subtitle"
    img: "image.png"

  - title: "Why are Swallows so good?"
    text: |-
      The great stadium in a good location
      A lot of star players
```
Also it would be nice to have some css-like features.